### PR TITLE
UX: fix avatar wrapping issue

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,10 +1,6 @@
 @use "lib/viewport";
 
 .discourse-custom-ad-component {
-  td {
-    width: 100%;
-  }
-
   a {
     box-sizing: border-box;
     display: flex;


### PR DESCRIPTION
Minor style fix that was causing avatars to wrap. 


Before:
![image](https://github.com/user-attachments/assets/4d62e448-7e53-4ce3-a3cf-79ef466e148c)


After: 
![image](https://github.com/user-attachments/assets/f8e078e4-55fa-438f-a85d-35e341ec7939)
