### PR TITLE
UX: only show ads on discovery routes

### DIFF
--- a/javascripts/discourse/components/ad-between-topics.gjs
+++ b/javascripts/discourse/components/ad-between-topics.gjs
@@ -54,6 +54,11 @@ export default class AdBetweenTopics extends Component {
     const category = this.router.currentRoute.attributes?.category?.id;
     const parentCategory =
       this.router.currentRoute.attributes?.category?.parent_category_id;
+    const isDiscovery = this.router.currentRouteName.includes("discovery");
+
+    if (!isDiscovery) {
+      return false;
+    }
 
     if (settings.exclude_categories) {
       const excludedCategories = settings.exclude_categories


### PR DESCRIPTION
This ensures the ads only show up on discovery routes, and not in topic lists for messages, personal activity, or group activity. 