### PR TITLE
UX: use text for ad disclosure

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -19,27 +19,25 @@
     @include viewport.from(sm) {
       padding: 0.55em 0.85em 0.65em;
       gap: 0.5em;
-      align-items: baseline;
     }
 
     .discourse-no-touch & {
       &:hover {
-        color: var(--tertiary);
-        text-decoration: underline;
+        .text-content {
+          color: var(--tertiary);
+          text-decoration: underline;
+        }
       }
     }
   }
 
-  .d-icon {
-    color: var(--primary-medium);
-
-    @include viewport.until(sm) {
-      font-size: var(--font-up-1);
-    }
-
-    @include viewport.from(sm) {
-      position: relative;
-      top: 0.15em; // optical alignment
-    }
+  .disclosure {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--primary-low);
+    padding: 0.15em 0.25em;
+    border-radius: 0.25em;
+    font-size: var(--font-down-2);
   }
 }

--- a/javascripts/discourse/components/ad-between-topics.gjs
+++ b/javascripts/discourse/components/ad-between-topics.gjs
@@ -4,8 +4,8 @@ import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { service } from "@ember/service";
-import icon from "discourse/helpers/d-icon";
 import { bind } from "discourse/lib/decorators";
+import { i18n } from "discourse-i18n";
 
 function _impressionForPlausible(event) {
   if (window.plausible) {
@@ -148,8 +148,11 @@ export default class AdBetweenTopics extends Component {
               rel="noopener noreferrer nofollow sponsored"
               class={{this.currentAdData.customClasses}}
             >
-              {{icon "rectangle-ad"}}
-              {{this.currentAdData.text}}
+              <span class="disclosure">
+                {{i18n (themePrefix "disclosure")}}
+
+              </span>
+              <span class="text-content">{{this.currentAdData.text}} </span>
             </a>
           {{/if}}
         </td>

--- a/javascripts/discourse/components/ad-between-topics.gjs
+++ b/javascripts/discourse/components/ad-between-topics.gjs
@@ -150,7 +150,6 @@ export default class AdBetweenTopics extends Component {
             >
               <span class="disclosure">
                 {{i18n (themePrefix "disclosure")}}
-
               </span>
               <span class="text-content">{{this.currentAdData.text}} </span>
             </a>

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -18,3 +18,4 @@ en:
               description: "Exclude members of these groups. Format as a comma-separated list of group names."
             custom_class:
               description: "Comma-separated custom CSS classes for the ad"
+  disclosure: "Ad"

--- a/settings.yml
+++ b/settings.yml
@@ -37,8 +37,3 @@ ads_impression_event_name:
 plausible_integration_enabled:
   type: bool
   default: false
-
-svg_icons:
-  default: "rectangle-ad"
-  type: "list"
-  list_type: "compact"


### PR DESCRIPTION
This moves the icon to live text, which is translatable, a little easier to read, and less likely to be caught by ad blockers. 

Before:
![image](https://github.com/user-attachments/assets/5b273c7d-3aa2-48bd-9543-8e17bb4f7009)


After: 
![image](https://github.com/user-attachments/assets/cb0898dc-0b24-4136-a432-fe51ba218961)
