### PR TITLE
DEV: Track page in Plausible

### DIFF
--- a/javascripts/discourse/components/ad-between-posts.gjs
+++ b/javascripts/discourse/components/ad-between-posts.gjs
@@ -10,6 +10,7 @@ import { i18n } from "discourse-i18n";
 
 export default class AdBetweenPosts extends Component {
   @service adConfigurator;
+  @service router;
 
   @tracked currentAdData;
 
@@ -26,6 +27,13 @@ export default class AdBetweenPosts extends Component {
         { ad_placement: "between_posts" }
       );
     }
+  }
+
+  get linkClasses() {
+    const plausibleClass = `plausible-event-page=${this.router.currentRouteName}`;
+    return [plausibleClass, this.currentAdData?.customClasses]
+      .filter(Boolean)
+      .join(" ");
   }
 
   get shouldShow() {
@@ -111,7 +119,7 @@ export default class AdBetweenPosts extends Component {
               href={{this.currentAdData.finalLink}}
               target="_blank"
               rel="noopener noreferrer nofollow sponsored"
-              class={{this.currentAdData.customClasses}}
+              class={{this.linkClasses}}
             >
               <span class="disclosure">
                 {{i18n (themePrefix "disclosure")}}

--- a/javascripts/discourse/components/ad-between-posts.gjs
+++ b/javascripts/discourse/components/ad-between-posts.gjs
@@ -30,7 +30,10 @@ export default class AdBetweenPosts extends Component {
   }
 
   get linkClasses() {
-    const plausibleClass = `plausible-event-page=${this.router.currentRouteName}`;
+    const page = this.router.currentRouteName
+      .replace(/^discovery\./, "")
+      .split(".")[0];
+    const plausibleClass = `plausible-event-page=${page}`;
     return [plausibleClass, this.currentAdData?.customClasses]
       .filter(Boolean)
       .join(" ");

--- a/javascripts/discourse/components/ad-between-posts.gjs
+++ b/javascripts/discourse/components/ad-between-posts.gjs
@@ -30,9 +30,7 @@ export default class AdBetweenPosts extends Component {
   }
 
   get linkClasses() {
-    const page = this.router.currentRouteName
-      .replace(/^discovery\./, "")
-      .split(".")[0];
+    const page = this.router.currentURL?.split("?")[0].replace(/^\//, "");
     const plausibleClass = `plausible-event-page=${page}`;
     return [plausibleClass, this.currentAdData?.customClasses]
       .filter(Boolean)

--- a/javascripts/discourse/components/ad-between-topics.gjs
+++ b/javascripts/discourse/components/ad-between-topics.gjs
@@ -18,6 +18,13 @@ export default class AdBetweenTopics extends Component {
   intersectionObserver = null;
   adElement = null;
 
+  get linkClasses() {
+    const plausibleClass = `plausible-event-page=${this.router.currentRouteName}`;
+    return [plausibleClass, this.currentAdData?.customClasses]
+      .filter(Boolean)
+      .join(" ");
+  }
+
   get shouldShow() {
     const isDiscovery = this.router.currentRouteName.includes("discovery");
     if (!isDiscovery) {
@@ -93,7 +100,7 @@ export default class AdBetweenTopics extends Component {
               href={{this.currentAdData.finalLink}}
               target="_blank"
               rel="noopener noreferrer nofollow sponsored"
-              class={{this.currentAdData.customClasses}}
+              class={{this.linkClasses}}
             >
               <span class="disclosure">
                 {{i18n (themePrefix "disclosure")}}

--- a/javascripts/discourse/components/ad-between-topics.gjs
+++ b/javascripts/discourse/components/ad-between-topics.gjs
@@ -19,7 +19,10 @@ export default class AdBetweenTopics extends Component {
   adElement = null;
 
   get linkClasses() {
-    const plausibleClass = `plausible-event-page=${this.router.currentRouteName}`;
+    const page = this.router.currentRouteName
+      .replace(/^discovery\./, "")
+      .split(".")[0];
+    const plausibleClass = `plausible-event-page=${page}`;
     return [plausibleClass, this.currentAdData?.customClasses]
       .filter(Boolean)
       .join(" ");

--- a/javascripts/discourse/components/ad-between-topics.gjs
+++ b/javascripts/discourse/components/ad-between-topics.gjs
@@ -19,9 +19,7 @@ export default class AdBetweenTopics extends Component {
   adElement = null;
 
   get linkClasses() {
-    const page = this.router.currentRouteName
-      .replace(/^discovery\./, "")
-      .split(".")[0];
+    const page = this.router.currentURL?.split("?")[0].replace(/^\//, "");
     const plausibleClass = `plausible-event-page=${page}`;
     return [plausibleClass, this.currentAdData?.customClasses]
       .filter(Boolean)

--- a/javascripts/discourse/services/ad-configurator.js
+++ b/javascripts/discourse/services/ad-configurator.js
@@ -39,6 +39,7 @@ function parseCustomClasses(ad) {
 
 export default class AdConfigurator extends Service {
   @service currentUser;
+  @service router;
 
   @tracked _eligibleAds = [];
 
@@ -173,8 +174,10 @@ export default class AdConfigurator extends Service {
   }
 
   trackImpression(adData) {
+    const props = { ...adData, page: this.router.currentRouteName };
+
     if (settings.plausible_integration_enabled && window.plausible) {
-      window.plausible(settings.ads_impression_event_name, { props: adData });
+      window.plausible(settings.ads_impression_event_name, { props });
     } else {
       // eslint-disable-next-line no-console
       console.log(

--- a/javascripts/discourse/services/ad-configurator.js
+++ b/javascripts/discourse/services/ad-configurator.js
@@ -39,7 +39,6 @@ function parseCustomClasses(ad) {
 
 export default class AdConfigurator extends Service {
   @service currentUser;
-  @service router;
 
   @tracked _eligibleAds = [];
 
@@ -174,10 +173,8 @@ export default class AdConfigurator extends Service {
   }
 
   trackImpression(adData) {
-    const props = { ...adData, page: this.router.currentRouteName };
-
     if (settings.plausible_integration_enabled && window.plausible) {
-      window.plausible(settings.ads_impression_event_name, { props });
+      window.plausible(settings.ads_impression_event_name, { props: adData });
     } else {
       // eslint-disable-next-line no-console
       console.log(


### PR DESCRIPTION
This PR adds a plausible-event-page class to ads.

<img width="272" height="121" alt="Screenshot 2026-04-22 at 9 35 26 AM" src="https://github.com/user-attachments/assets/98532c9a-e423-4f31-a780-031247a9cf90" />
<img width="260" height="138" alt="Screenshot 2026-04-22 at 9 35 32 AM" src="https://github.com/user-attachments/assets/97cb8bf9-4cff-4ee2-b44d-4fa77e006816" />
<img width="275" height="117" alt="Screenshot 2026-04-22 at 9 35 37 AM" src="https://github.com/user-attachments/assets/15a73617-819e-4933-9b3e-642eff7c6e18" />
<img width="388" height="138" alt="Screenshot 2026-04-22 at 9 35 47 AM" src="https://github.com/user-attachments/assets/170ce789-e461-447b-9d2e-e7953fd3246d" />
