### PR TITLE
FIX: Render between-posts ads correctly in the nested replies view

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -32,6 +32,14 @@
     }
   }
 
+  &.--between-nested-roots {
+    a {
+      justify-content: center;
+      border: 1px solid var(--primary-low);
+      border-radius: var(--d-border-radius);
+    }
+  }
+
   &.--between-posts {
     a {
       border-top: 1px solid var(--primary-low);

--- a/javascripts/discourse/api-initializers/topic-ad-connector.gjs
+++ b/javascripts/discourse/api-initializers/topic-ad-connector.gjs
@@ -1,6 +1,8 @@
 import { apiInitializer } from "discourse/lib/api";
+import AdBetweenNestedRoots from "../components/ad-between-nested-roots";
 import AdBetweenPosts from "../components/ad-between-posts";
 
 export default apiInitializer((api) => {
   api.renderAfterWrapperOutlet("post-article", AdBetweenPosts);
+  api.renderInOutlet("nested-roots-between", AdBetweenNestedRoots);
 });

--- a/javascripts/discourse/components/ad-between-nested-roots.gjs
+++ b/javascripts/discourse/components/ad-between-nested-roots.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
@@ -8,33 +7,20 @@ import { bind } from "discourse/lib/decorators";
 import Category from "discourse/models/category";
 import { i18n } from "discourse-i18n";
 
-export default class AdBetweenPosts extends Component {
-  // The nested replies view renders the `post-article` outlet for every post
-  // at every depth; ads between its top-level replies are handled by
-  // `AdBetweenNestedRoots` instead.
-  static shouldRender(args) {
-    return !args.nestedReplyView;
-  }
-
+export default class AdBetweenNestedRoots extends Component {
   @service adConfigurator;
   @service router;
 
-  @tracked currentAdData;
+  currentAdData =
+    settings.show_between_posts !== 0
+      ? this.adConfigurator.getAdForSlot(
+          (this.args.index + 1) % settings.show_between_posts === 0,
+          { ad_placement: "between_posts" }
+        )
+      : null;
 
   intersectionObserver = null;
   adElement = null;
-
-  constructor() {
-    super(...arguments);
-
-    if (settings.show_between_posts !== 0) {
-      this.currentAdData = this.adConfigurator.getAdForSlot(
-        this.args.post?.post_number === 1 ||
-          this.args.post?.post_number % settings.show_between_posts === 0,
-        { ad_placement: "between_posts" }
-      );
-    }
-  }
 
   get linkClasses() {
     const page = this.router.currentURL?.split("?")[0].replace(/^\//, "");
@@ -45,29 +31,19 @@ export default class AdBetweenPosts extends Component {
   }
 
   get shouldShow() {
-    const categoryId = this.args.post?.topic?.category_id;
+    const categoryId = this.args.topic?.category_id;
     const category = Category.findById(categoryId);
-    const parentCategoryId = category?.parent_category_id;
 
-    if (settings.exclude_categories) {
-      const excludedCategories = settings.exclude_categories
-        .split("|")
-        .map((cat) => parseInt(cat, 10));
-      if (
-        excludedCategories.includes(categoryId) ||
-        excludedCategories.includes(parentCategoryId)
-      ) {
-        return false;
-      }
+    if (
+      this.adConfigurator.shouldExcludeCategory(
+        categoryId,
+        category?.parent_category_id
+      )
+    ) {
+      return false;
     }
 
     return !!this.currentAdData;
-  }
-
-  get afterLastPost() {
-    return (
-      this.args.post?.topic.highest_post_number === this.args.post?.post_number
-    );
   }
 
   @bind
@@ -118,8 +94,7 @@ export default class AdBetweenPosts extends Component {
       <div
         {{didInsert this.setupAdImpressionTracking}}
         {{willDestroy this.cleanUp}}
-        class="discourse-custom-ad-component --between-posts
-          {{if this.afterLastPost '--last-post'}}"
+        class="discourse-custom-ad-component --between-nested-roots"
       >
         <div>
           {{#if this.currentAdData.link}}

--- a/spec/system/ads_between_nested_roots_spec.rb
+++ b/spec/system/ads_between_nested_roots_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe "Ads between nested roots", system: true do
+  fab!(:theme) { upload_theme_component }
+  fab!(:topic)
+  fab!(:op) { Fabricate(:post, topic: topic) }
+  fab!(:root_replies) { Fabricate.times(7, :post, topic: topic) }
+
+  let(:ads_config) do
+    [
+      {
+        id: "ad-post-1",
+        text: "Post Ad for All",
+        link: "https://example.com/ad1",
+        utm_source: "discourse",
+        include_groups: "",
+        exclude_groups: "",
+      },
+    ]
+  end
+
+  before do
+    SiteSetting.nested_replies_enabled = true
+    SiteSetting.nested_replies_default_sort = "old"
+    theme.update_setting(:ads, ads_config)
+    theme.update_setting(:show_between_posts, 3)
+    theme.update_setting(:exclude_categories, "")
+    theme.save!
+  end
+
+  it "shows ads between every nth top-level reply and none inside the reply tree" do
+    visit("/n/#{topic.slug}/#{topic.id}")
+
+    expect(page).to have_css(".nested-view")
+    expect(page).to have_css(
+      ".discourse-custom-ad-component.--between-nested-roots a[href*='example.com/ad1']",
+      count: 2,
+    )
+    expect(page).to have_css(
+      ".nested-post:has([data-post-number='#{root_replies[2].post_number}']) + .discourse-custom-ad-component.--between-nested-roots",
+    )
+    expect(page).to have_no_css(".nested-post .discourse-custom-ad-component")
+    expect(page).to have_no_css(".nested-view__op .discourse-custom-ad-component")
+  end
+end


### PR DESCRIPTION
Previously, the between-posts ad was rendered through the `post-article` wrapper outlet, which the nested replies view renders for the OP and for every reply at every depth — so ads appeared inside the OP card and scattered throughout the reply tree, gated by `post_number`, which does not reflect display order in that view.

This change skips the between-posts ad in the nested replies view (via `shouldRender` on the `nestedReplyView` outlet arg) and adds an `AdBetweenNestedRoots` component rendered in the core `nested-roots-between` outlet, which shows an ad after every `show_between_posts` top-level replies instead.

On Discourse versions without the `nested-roots-between` outlet the new component never renders, and the regular topic view is unchanged.