### PR TITLE
UX: Add a dedicated ad cadence setting for the nested replies view

### DIFF
--- a/javascripts/discourse/components/ad-between-nested-roots.gjs
+++ b/javascripts/discourse/components/ad-between-nested-roots.gjs
@@ -12,9 +12,9 @@ export default class AdBetweenNestedRoots extends Component {
   @service router;
 
   currentAdData =
-    settings.show_between_posts !== 0
+    settings.show_between_nested_roots !== 0
       ? this.adConfigurator.getAdForSlot(
-          (this.args.index + 1) % settings.show_between_posts === 0,
+          (this.args.index + 1) % settings.show_between_nested_roots === 0,
           { ad_placement: "between_posts" }
         )
       : null;

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,6 +6,8 @@ en:
         description: "Number of topics between ads in the topic list"
       show_between_posts:
         description: "Number of posts between ads within a topic"
+      show_between_nested_roots:
+        description: "Number of top-level replies between ads in the nested replies view. Set to 0 to disable."
       ads:
         description: "Ad content, links, and visibility"
         schema:

--- a/settings.yml
+++ b/settings.yml
@@ -6,6 +6,10 @@ show_between_posts:
   type: integer
   default: 10
 
+show_between_nested_roots:
+  type: integer
+  default: 5
+
 exclude_categories:
   type: list
   list_type: category

--- a/spec/system/ads_between_nested_roots_spec.rb
+++ b/spec/system/ads_between_nested_roots_spec.rb
@@ -23,7 +23,11 @@ RSpec.describe "Ads between nested roots", system: true do
     SiteSetting.nested_replies_enabled = true
     SiteSetting.nested_replies_default_sort = "old"
     theme.update_setting(:ads, ads_config)
-    theme.update_setting(:show_between_posts, 3)
+    # The nested view cadence must come from show_between_nested_roots, not
+    # show_between_posts — set the latter high enough that reusing it by
+    # mistake would render no ads at all.
+    theme.update_setting(:show_between_posts, 50)
+    theme.update_setting(:show_between_nested_roots, 3)
     theme.update_setting(:exclude_categories, "")
     theme.save!
   end


### PR DESCRIPTION
Previously, ads between top-level replies in the nested replies view reused `show_between_posts`, but that cadence counts all posts in the classic view while only roots count in the nested view — with `show_between_posts: 15`, a topic with hundreds of posts but few top-level replies showed barely any ads.

This change adds a `show_between_nested_roots` setting (default 5) so the nested view cadence can be tuned independently, with 0 disabling nested-view ads.

Follow-up to #25.